### PR TITLE
Modified: save layout container positions when refreshing

### DIFF
--- a/components/grid-layout-component/grid-layout-component.tsx
+++ b/components/grid-layout-component/grid-layout-component.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import GridLayout from "react-grid-layout";
 import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";
@@ -9,23 +9,31 @@ import { data, productSales, salesData } from "@/mockdata";
 const ResponsiveGridLayout = WidthProvider(GridLayout);
 
 export function GridLayoutComponent() {
-  const layout = [
+  const defaultLayout = [
     { i: "0", x: 0, y: 0, w: 3, h: 2 },
     { i: "1", x: 3, y: 0, w: 4, h: 2 },
     { i: "2", x: 0, y: 0, w: 4, h: 2 },
     { i: "3", x: 8, y: 0, w: 5, h: 4 },
   ];
-  const layout2 = [
-    { i: "0", x: 0, y: 0, w: 3, h: 2 },
-    { i: "1", x: 3, y: 0, w: 4, h: 2 },
-    { i: "2", x: 0, y: 0, w: 4, h: 2 },
-    { i: "3", x: 4, y: 0, w: 5, h: 2 },
-  ];
+
+  const [layout, setLayout] = useState(() => {
+    const savedLayout = localStorage.getItem("layout");
+    return savedLayout ? JSON.parse(savedLayout) : defaultLayout;
+  });
+
+  useEffect(() => {
+    localStorage.setItem("layout", JSON.stringify(layout));
+  }, [layout]);
+
+  const onLayoutChange = (newLayout: any) => {
+    setLayout(newLayout);
+  };
 
   return (
     <ResponsiveGridLayout
       className="layout"
       layout={layout}
+      onLayoutChange={onLayoutChange}
       isBounded={true}
       compactType={null}
       margin={[10, 10]}

--- a/components/grid-layout-component/grid-layout-component.tsx
+++ b/components/grid-layout-component/grid-layout-component.tsx
@@ -17,7 +17,7 @@ export function GridLayoutComponent() {
   ];
 
   const [layout, setLayout] = useState(() => {
-    const savedLayout = localStorage.getItem("layout");
+    const savedLayout = (typeof window !== "undefined") ? localStorage.getItem("layout") : null;
     return savedLayout ? JSON.parse(savedLayout) : defaultLayout;
   });
 


### PR DESCRIPTION
Cada vez que se actualiza la página desde que las cajas se habían movido o cambiado de tamaño, siguen estado donde se cambiaron últimamente y no por el valor inicial por defecto.